### PR TITLE
Added rhsm-subscribe and rhsm-unsubscribe under packer_templates/cent…

### DIFF
--- a/packer_templates/centos/scripts/rhsm-subscribe.sh
+++ b/packer_templates/centos/scripts/rhsm-subscribe.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -eux
+
+## Red Hat Subscription-Manager (RHSM)
+## Script by Stephen Leahy and Ben Colby-Sexton
+## sleahy@redhat.com
+## bcs@redhat.com
+## 21/06/2019
+##
+## Register to RHSM for testing of specific repositories
+
+IFS=","
+
+/usr/sbin/subscription-manager register --username=$RH_USERNAME --password=$RH_PASSWORD
+
+if [[ $? = 0 ]]; then
+  for POOL in $POOL_IDS; do
+    /usr/sbin/subscription-manager attach --pool=$POOL
+  done
+else
+  echo "Unable to register with RHSM"
+  exit 1
+fi
+

--- a/packer_templates/centos/scripts/rhsm-unsubscribe.sh
+++ b/packer_templates/centos/scripts/rhsm-unsubscribe.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eux
+
+## Red Hat Subscription-Manager (RHSM)
+## Script by Stephen Leahy
+## sleahy@redhat.com
+## 21/06/2019
+##
+## Unsubscribe from RHSM
+
+subscription-manager unregister --username=$RH_USERNAME


### PR DESCRIPTION
…os/scripts/ to subscribe and unsubscribe from RHSM in order to test specific repositories

### Description

Adds RHSM Subscription scripts for allowing the creating of RHEL Vagrant boxes, so long as you have a valid subscription, and the details for said subscription.
